### PR TITLE
Fix 2022 changelog link error

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -102,7 +102,7 @@
 
 ## 更早年份的更新
 
-* [2022](changelogs/2021.md) :blossom:
+* [2022](changelogs/2022.md) :blossom:
 * [2021](changelogs/2021.md) :balloon:
 * [2020](changelogs/2020.md) :butterfly:
 * [2019](changelogs/2019.md) :sparkles:


### PR DESCRIPTION
修复
[更新日志](https://wiki.nyaa.cat/#/changelog)-[更早年份的更新](https://wiki.nyaa.cat/#/changelog?id=%e6%9b%b4%e6%97%a9%e5%b9%b4%e4%bb%bd%e7%9a%84%e6%9b%b4%e6%96%b0)中
2022年的链接错误